### PR TITLE
Feat/프로필 조회 기능 구현 및 로그인 응답값추가

### DIFF
--- a/src/main/java/com/example/tutoring/controller/ProfileController.java
+++ b/src/main/java/com/example/tutoring/controller/ProfileController.java
@@ -142,4 +142,12 @@ public class ProfileController {
 
 		return profileService.myNotice(accessToken);
 	}
+	
+	//회원 프로필 조회
+	@GetMapping("/profileInfo")
+	public ResponseEntity<Map<String,Object>> profileInfo(@RequestParam("memberNum")int memberNum)
+	{
+		log.info("----/profile/profileInfo API 진입----");
+		return profileService.profileInfo(memberNum);
+	}
 }

--- a/src/main/java/com/example/tutoring/repository/FollowRepository.java
+++ b/src/main/java/com/example/tutoring/repository/FollowRepository.java
@@ -60,5 +60,13 @@ public interface FollowRepository extends JpaRepository<Follow, Integer> {
     @Transactional
     @Query("DELETE FROM Follow f WHERE f.followerMemberNum = :followerMemberNum AND f.followingMemberNum = :followingMemberNum")
     void deleteFollowMember(@Param("followerMemberNum") int followerNum, @Param("followingMemberNum") int followingNum);
+    
+    
+    //팔로워 카운트(회원을 팔로우하는)
+  	@Query("SELECT COUNT(f) FROM Follow f WHERE f.followingMemberNum = :memberNum")
+  	int followerCount(@Param("memberNum") int memberNum);
 
+  	//팔로잉 카운트(회원이 팔로우하는)
+  	@Query("SELECT COUNT(f) FROM Follow f WHERE f.followerMemberNum = :memberNum")
+  	int followingCount(@Param("memberNum") int memberNum);
 }

--- a/src/main/java/com/example/tutoring/repository/NoticeRepository.java
+++ b/src/main/java/com/example/tutoring/repository/NoticeRepository.java
@@ -1,6 +1,8 @@
 package com.example.tutoring.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.tutoring.entity.Notice;
@@ -12,4 +14,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Integer> {
 
     // memberNum에 해당하는 공지글 목록 조회
     List<Notice> findByMemberNum(Integer memberNum);
+    
+    // 게시글 카운트
+	@Query("SELECT COUNT(n) FROM Notice n WHERE n.memberNum = :memberNum")
+  	int noticeCount(@Param("memberNum") int memberNum);
 }

--- a/src/main/java/com/example/tutoring/service/MemberService.java
+++ b/src/main/java/com/example/tutoring/service/MemberService.java
@@ -4,7 +4,9 @@ import com.example.tutoring.dto.MemberDto;
 import com.example.tutoring.entity.Member;
 import com.example.tutoring.jwt.CustomUserDetails;
 import com.example.tutoring.jwt.JwtTokenProvider;
+import com.example.tutoring.repository.FollowRepository;
 import com.example.tutoring.repository.MemberRepository;
+import com.example.tutoring.repository.NoticeRepository;
 import com.example.tutoring.repository.RefreshTokenRespository;
 import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,12 @@ public class MemberService {
 
 	@Autowired
     private MemberRepository memberRepository;
+	
+	@Autowired
+	private NoticeRepository noticeRepository;
+	
+	@Autowired
+	private FollowRepository followRepository;
 
 	@Autowired
 	private RefreshTokenRespository refreshTokenRespository;
@@ -110,7 +118,10 @@ public class MemberService {
 
     	String memberId = loginData.get("memberId").toString();
     	String password = loginData.get("password").toString();
-
+    	
+		int followerCnt = 0;
+		int followCnt = 0;
+		int noticeCnt = 0;
     	try {
 
     		UsernamePasswordAuthenticationToken authenticationToken =
@@ -126,6 +137,10 @@ public class MemberService {
 
         	String accessToken = jwtTokenProvider.createAccessToken(memberNumString);
         	jwtTokenProvider.createRefreshToken(memberNumString);
+        	
+        	followerCnt = followRepository.followerCount(member.getMemberNum());
+			followCnt = followRepository.followingCount(member.getMemberNum());
+			noticeCnt = noticeRepository.noticeCount(member.getMemberNum());     	
 
              responseMap.put("memberNum", member.getMemberNum());
              responseMap.put("loginType", member.getLoginType());
@@ -134,6 +149,9 @@ public class MemberService {
              responseMap.put("introduction", member.getIntroduction());
              responseMap.put("access", accessToken);
              responseMap.put("hasNotice", false);
+             responseMap.put("followCount", followCnt);
+ 			 responseMap.put("followerCount", followerCnt);
+ 			 responseMap.put("noticeCount", noticeCnt);
 
              return ResponseEntity.status(HttpStatus.OK).body(responseMap);
 

--- a/src/main/java/com/example/tutoring/service/ProfileService.java
+++ b/src/main/java/com/example/tutoring/service/ProfileService.java
@@ -296,7 +296,7 @@ public class ProfileService {
 			followRepository.deleteFollowMember(followMemberNum,myMemberNum);
 
 			responseMap.put("message", "팔로워 삭제 성공");
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseMap);
+			return ResponseEntity.status(HttpStatus.OK).body(responseMap);
 		}catch(Exception e)
 		{
 			log.info(e.getMessage());
@@ -333,4 +333,37 @@ public class ProfileService {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
 		}
 	}
+	
+	public ResponseEntity<Map<String, Object>> profileInfo(int memberNum)
+	{
+		Map<String,Object> response = new HashMap<String, Object>();
+		
+		int followerCnt = 0;
+		int followCnt = 0;
+		int noticeCnt = 0;
+		
+		try {
+			Member member = memberRepository.findById(memberNum).get();
+			followerCnt = followRepository.followerCount(memberNum);
+			followCnt = followRepository.followingCount(memberNum);
+			noticeCnt = noticeRepository.noticeCount(memberNum);
+						
+			response.put("memberNum", member.getMemberNum());
+			response.put("nickname", member.getNickname());
+			response.put("profileImg", member.getProfileImg());
+			response.put("introduction",member.getIntroduction());
+			response.put("followCount", followCnt);
+			response.put("followerCnt", followerCnt);
+			response.put("noticeCount", noticeCnt);
+			
+			return ResponseEntity.status(HttpStatus.OK).body(response);
+		}catch(Exception e)
+		{
+			response.put("message", e.getMessage());
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+		}
+				
+		
+	}
+	
 }


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 디자인

## 반영 브랜치
feat/profile_info -> develop

## 변경 사항
- 회원 프로필 조회 기능 구현
- 기존의 로그인 응답값에 팔로잉, 팔로워, 공지글 수 추가

## 테스트 결과
- 프로필 조회
![image](https://github.com/user-attachments/assets/887d0fef-73e1-4bf4-9e19-b5851bac39f1)

- 로그인 응답값 추가
![image](https://github.com/user-attachments/assets/39646eb6-b26a-4670-85db-2617db9aa813)


## ETC
추가적으로 적을 내용이 있으면 적어주세요. (선택)
