### PR TITLE
Fix | 맞팔로우 로직 수정

### DIFF
--- a/src/main/java/com/example/tutoring/repository/FollowRepository.java
+++ b/src/main/java/com/example/tutoring/repository/FollowRepository.java
@@ -16,7 +16,12 @@ public interface FollowRepository extends JpaRepository<Follow, Integer> {
 	//팔로우 체크
 	@Query("SELECT COUNT(f) FROM Follow f WHERE f.followerMemberNum = :followerMemberNum AND f.followingMemberNum = :followingMemberNum")
 	int followCheck(@Param("followerMemberNum") int followerNum, @Param("followingMemberNum") int followingNum);
-	   
+	 
+	//맞팔로우 체크
+	@Query("SELECT COUNT(f) FROM Follow f WHERE (f.followerMemberNum = :followerMemberNum AND f.followingMemberNum = :followingMemberNum) "+
+	"OR (f.followingMemberNum = :followerMemberNum AND f.followerMemberNum = :followingMemberNum)")
+	int eachFollowCheck(@Param("followerMemberNum") int followerNum, @Param("followingMemberNum") int followingNum);
+	 	
     //내가 팔로우한 멤버 목록 조회
     @Query(value="SELECT m.memberNum, m.nickname, m.profileImg, m.introduction " +
     	       "FROM follow f JOIN member m ON f.followingMemberNum = m.memberNum " +

--- a/src/main/java/com/example/tutoring/service/ProfileService.java
+++ b/src/main/java/com/example/tutoring/service/ProfileService.java
@@ -116,7 +116,7 @@ public class ProfileService {
 			int pageSize = 10;
 			int offset = observer * pageSize;
 			
-			int myMemeberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
+			int myMemberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
 			
 			List<Object[]> result = followRepository.findFollowerMemberList(memberNum, pageSize, offset);
 			List<FollowResponseDto> followerList = new ArrayList<>();
@@ -125,9 +125,18 @@ public class ProfileService {
 				String nickname = (String) obj[1];
 				String profileImg = (String) obj[2];
 				String introduction = (String) obj[3];
+								
 				boolean status = true;
-				if(followRepository.followCheck(followMemberNum, myMemeberNum) < 1)
-					status = false;
+				
+				if(followMemberNum == myMemberNum)
+				{
+					if(followRepository.followCheck(memberNum, myMemberNum) != 1)
+						status= false;
+				}else {
+					if(followRepository.eachFollowCheck(followMemberNum, myMemberNum) != 2)
+						status = false;
+				}												
+				
 								
 				followerList.add(new FollowResponseDto(followMemberNum, nickname, profileImg, introduction, status));
 			}
@@ -155,7 +164,7 @@ public class ProfileService {
 			int pageSize = 10;
 			int offset = observer * pageSize;
 			
-			int myMemeberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
+			int myMemberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
 
 			List<Object[]> result = followRepository.findFollowingMemberList(memberNum, pageSize, offset);
 
@@ -167,8 +176,15 @@ public class ProfileService {
 				String introduction = (String) obj[3];
 				
 				boolean status = true;
-				if(followRepository.followCheck(followMemberNum, myMemeberNum) < 1)
-					status = false;
+				
+				if(followMemberNum == myMemberNum)
+				{
+					if(followRepository.followCheck(myMemberNum, memberNum) != 1)
+						status= false;
+				}else {
+					if(followRepository.eachFollowCheck(followMemberNum, myMemberNum) != 2)
+						status = false;
+				}				
 
 				followingList.add(new FollowResponseDto(followMemberNum, nickname, profileImg, introduction,status));
 			}
@@ -214,7 +230,7 @@ public class ProfileService {
 			int pageSize = 10;
 			int offset = observer * pageSize;
 
-			int myMemeberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
+			int myMemberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
 			
 			List<Object[]> result = followRepository.findSearchFollowerMemberList(memberNum, searchName, pageSize, offset);
 			List<FollowResponseDto> followerList = new ArrayList<>();
@@ -225,8 +241,15 @@ public class ProfileService {
 				String introduction = (String) obj[3];
 				
 				boolean status = true;
-				if(followRepository.followCheck(followMemberNum, myMemeberNum) < 1)
-					status = false;
+				
+				if(followMemberNum == myMemberNum)
+				{
+					if(followRepository.followCheck(memberNum, myMemberNum) != 1)
+						status= false;
+				}else {
+					if(followRepository.eachFollowCheck(followMemberNum, myMemberNum) != 2)
+						status = false;
+				}	
 				
 				followerList.add(new FollowResponseDto(followMemberNum, nickname, profileImg, introduction,status));
 			}
@@ -256,7 +279,7 @@ public class ProfileService {
 			int pageSize = 10;
 			int offset = observer * pageSize;
 			
-			int myMemeberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
+			int myMemberNum = Integer.parseInt(jwtTokenProvider.getMemberNum(accessToken));
 
 			List<Object[]> result = followRepository.findSearchFollowingMemberList(memberNum, searchName, pageSize, offset);
 			List<FollowResponseDto> followingList = new ArrayList<>();
@@ -267,8 +290,15 @@ public class ProfileService {
 				String introduction = (String) obj[3];
 				
 				boolean status = true;
-				if(followRepository.followCheck(followMemberNum, myMemeberNum) < 1)
-					status = false;
+				
+				if(followMemberNum == myMemberNum)
+				{
+					if(followRepository.followCheck(myMemberNum, memberNum) != 1)
+						status= false;
+				}else {
+					if(followRepository.eachFollowCheck(followMemberNum, myMemberNum) != 2)
+						status = false;
+				}	
 				
 				followingList.add(new FollowResponseDto(followMemberNum, nickname, profileImg, introduction,status));
 			}


### PR DESCRIPTION
# Pull Request 🙇🏻‍♀

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인

## 반영 브랜치
fix/follow_list_logic_updaet -> develop

## 변경 사항
- 로그인한 회원이 다른 회원의 팔로워 목록을 봤을때 맞팔로우 처리가 안되어 있었음
- 쿼리 및 코드에 조건절 추가하여 해결

## 테스트 결과
- 맞팔로우 처리 확인
- 서로 팔로우한 두 계정에서 본인과 팔로우한 회원의 목록에 status : true 확인